### PR TITLE
make `echo`  break line

### DIFF
--- a/remote_dumps/quagga_parse.sh
+++ b/remote_dumps/quagga_parse.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 for mrt in `ls dumps`; do
-    /bin/echo -n "processing $mrt...      "
+    echo "processing $mrt..."
     OUT=$mrt
     /usr/local/bin/bgpdump -vm dumps/$mrt | cut -d '|' -f '6,7' > paths/$OUT
 done


### PR DESCRIPTION
Simple change to make log cleaner.

Before:
![Screen Shot 2022-11-15 at 15 51 34](https://user-images.githubusercontent.com/19480819/202011251-50c2ede5-ad05-416c-9d01-f6d8fad72d54.png)

After:
<img width="374" alt="Screen Shot 2022-11-15 at 16 04 01" src="https://user-images.githubusercontent.com/19480819/202011280-6d493e41-deff-4c05-99e4-72c9b586920f.png">
